### PR TITLE
Don't delete window.affirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not delete `window.affirm` as `affirm.js` depends on it to work correctly
+
 ## [0.0.3] - 2020-12-04
+
+### Changed
+
+- Refresh Affirm UI on PDP if selected SKU changes
 
 ## [0.0.2] - 2020-05-07
 

--- a/react/components/hooks/useScriptLoader.tsx
+++ b/react/components/hooks/useScriptLoader.tsx
@@ -17,7 +17,6 @@ const useScriptLoader = <T extends object = any>(
 
     script.onload = () => {
       setX((window as any)[libName])
-      delete (window as any)[libName]
       document.body.removeChild(script)
     }
 


### PR DESCRIPTION
Previously, the `useScriptLoader` hook loaded the `affirm.js` script, saved `window.affirm` to component state and immediately deleted `window.affirm`, a common practice to prevent access to the `window.affirm` functions through the browser console. However, `affirm.js` includes some code that depends on `window.affirm` being available, and a recent change on Affirm's side exacerbated this problem, resulting in the Affirm Prequalify link on the PDP ceasing to function.  

This PR stops the deletion of `window.affirm` and the Prequalify link now works correctly.

New version linked here: https://arthur--eriksbikeshop.myvtex.com/volkl-deacon-xt-ski-with-vmotion-10-bindings-2021-pr3e26352/p?skuId=8061042

Compare to production where clicking Prequalify does nothing: https://eriksbikeshop.myvtex.com/volkl-deacon-xt-ski-with-vmotion-10-bindings-2021-pr3e26352/p?skuId=8061042 