### PR TITLE
[AFFIRM-27] Fix AffirmPromo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the AffirmPromo Icon not showing at some cases
+
 ## [0.0.7] - 2022-11-04
 
 ### Fixed

--- a/react/components/AffirmPromo.tsx
+++ b/react/components/AffirmPromo.tsx
@@ -33,7 +33,7 @@ const AffirmPromoDiv: StorefrontFunctionComponent<AffirmPromoProps> = ({
   const handles = useCssHandles(CSS_HANDLES)
 
   useEffect(() => {
-    if (!affirm || error || !publicApiKey || window._affirm_config) return
+    if (!affirm || error || !publicApiKey) return
 
     window._affirm_config = {
       public_api_key: publicApiKey,


### PR DESCRIPTION
**What problem is this solving?**

Originally, when you reach the product and open the product page, the Affirm promo Icon doesn't showup.  This is because the window._affirm_config is initialed so that the affirm ui won't refresh.

**How to test it?**

[Workspace](https://aurora--eriksbikeshop.myvtex.com)

steps to test
1: find a product
2. copy the name of that product and open that product page from search results
3. You should be able to see the Affirm promo icon






